### PR TITLE
Updated collection.load to accept workspace_handle

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -201,11 +201,13 @@ Collection.load = function*(args) {
 
 	var id = args.id;
 	var name = args.name;
+	var workspace_handle = args.workspace_handle;
 
 	var criteria = {};
 
 	if (id) { criteria.id = id; }
 	if (name) { criteria.name = name; }
+	if (workspace_handle) { criteria.workspace_handle = workspace_handle; }
 
 	var data = yield models.collections
 		.find({ where: criteria })

--- a/routes/api.js
+++ b/routes/api.js
@@ -20,7 +20,7 @@ exports.initialize = function(app) {
 		var data = req.body;
 		var user_id = api.user.id;
 
-		var collection = yield Collection.load({ name: collection_name });
+		var collection = yield Collection.load({ name: collection_name, workspace_handle: workspace.handle });
 
 		if (!collection) return res.json(404, {
 			message: "couldn't find collection",


### PR DESCRIPTION
Problem: If 2 collections have the same name but within different workspaces, then API preview would crash because collection.load would query collection by collection name criteria only.
Solution: Added workspace_handle to collection.load so it will load the correct collection from the correct workspace.
