### PR TITLE
Fixed image preview icon, which was not showing correctly

### DIFF
--- a/plugins/image/config.js
+++ b/plugins/image/config.js
@@ -7,9 +7,12 @@ module.exports = {
 	placeholder: '',
 	preview: function(value) {
 
-		try { var parsed_data = JSON.parse(value) } 
-		catch (e) { return "" }
-
+		if (typeof value !== 'object') {
+			try { JSON.parse(value) }
+			catch(e) { return '' }
+		} else if (value === null) {
+			return '';
+		}
 		return '<h4><i class="muted large icon-picture"></i></h4>';
 	},
 	deflate: function(field, item, models, callback) {


### PR DESCRIPTION
Image preview icon was always expecting a JSON, which is no longer the case anymore. Since we are properly saving JSON into storage, we should be getting back a valid javascript object
