### PR TITLE
Allow for custom validators for complex plugin field types

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -103,21 +103,30 @@ Item.prototype = {
 
 			if (data[field.name] !== undefined && data[field.name] !== '') {
 
-				var is_valid, error_detail;
+				var is_valid, error_message;
 
 				// allow for custom validators for complex plugin field types
 				if (typeof field.control.validator === 'function') {
-					var messages = [];
-					is_valid = field.control.validator(data[field.name], field, messages);
-					error_detail = messages.join(', ');
+					var validation = field.control.validator(data[field.name], field);
+					// validators may return an object or boolean result
+					if (typeof validation === 'object') {
+						is_valid = validation.is_valid;
+						error_message = validation.error_message;
+					} else {
+						is_valid = validation;
+					}
+
+					if (typeof error_message !== 'string' || error_message.length <= 0) {
+						error_message = 'invalid value';
+					}
 				} else {
 					var validator = validators[field.control.validator];
 					is_valid = validator ? validator(data[field.name] || "") : true;
-					error_detail = field.control.validator;
+					error_message = field.control.validator;
 				}
 
 				if (!is_valid) {
-					errors[field.name] = "Failed assertion: " + error_detail;
+					errors[field.name] = "Failed assertion: " + error_message;
 				}
 			}
 		});

--- a/lib/item.js
+++ b/lib/item.js
@@ -103,11 +103,21 @@ Item.prototype = {
 
 			if (data[field.name] !== undefined && data[field.name] !== '') {
 
-				var validator = validators[field.control.validator];
-				var is_valid = validator ? validator(data[field.name] || "") : true;
+				var is_valid, error_detail;
+
+				// allow for custom validators for complex plugin field types
+				if (typeof field.control.validator === 'function') {
+					var messages = [];
+					is_valid = field.control.validator(data[field.name], field, messages);
+					error_detail = messages.join(', ');
+				} else {
+					var validator = validators[field.control.validator];
+					is_valid = validator ? validator(data[field.name] || "") : true;
+					error_detail = field.control.validator;
+				}
 
 				if (!is_valid) {
-					errors[field.name] = "Failed assertion: " + field.control.validator;
+					errors[field.name] = "Failed assertion: " + error_detail;
 				}
 			}
 		});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "connect-domain": "0.5.0",
     "moment": "2.5.0",
     "gx": "https://github.com/dchester/gx/archive/v0.1.0.tar.gz",
-    "gnode": "0.0.8",
+    "gnode": "0.1.0",
     "config": "~0.4.35",
     "passport": "^0.2.0",
     "passport-local": "^1.0.0"

--- a/tests/item.js
+++ b/tests/item.js
@@ -192,15 +192,28 @@ exports.validateCustomType = function(test) {
 
 		// temporarily override the validator for isbn/number with a custom one
 		var isbn_field = item.collection.fields.filter(function(o) { return o.name === 'isbn'; }).pop();
-		isbn_field.control.validator = function(value,field,messages) {
-			messages.push("custom error message: "+value);
-			return 0;
+
+		isbn_field.control.validator = function(value,field) {
+			return { is_valid: false, error_message: "custom message: "+value };
 		};
+		test.deepEqual(item.validate(), { isbn: 'Failed assertion: custom message: 55555' }, 'validator returns object: invalid');
 
-		var errors = item.validate();
+		isbn_field.control.validator = function(value,field) { return { is_valid: false, error_message: '' }; };
+		test.deepEqual(item.validate(), { isbn: 'Failed assertion: invalid value' }, 'validator returns object; zero-length error message');
+
+		isbn_field.control.validator = function(value,field) { return { is_valid: false }; };
+		test.deepEqual(item.validate(), { isbn: 'Failed assertion: invalid value' }, 'validator returns object; but no error message');
+
+		isbn_field.control.validator = function(value,field) { return { is_valid: true }; };
+		test.deepEqual(item.validate(), null, 'validator returns object: valid');
+
+		isbn_field.control.validator = function(value,field) { return false; };
+		test.deepEqual(item.validate(), { isbn: 'Failed assertion: invalid value' }, 'validator returns boolean: invalid');
+
+		isbn_field.control.validator = function(value,field) { return true; };
+		test.deepEqual(item.validate(), null, 'validator returns boolean: valid');
+
 		isbn_field.control.validator = 'isNumeric'; // restore validator
-
-		test.deepEqual(errors, { isbn: 'Failed assertion: custom error message: 55555' });
 		test.done();
 	});
 };

--- a/tests/item.js
+++ b/tests/item.js
@@ -168,6 +168,43 @@ exports.validateType = function(test) {
 	});
 };
 
+exports.validateCustomType = function(test) {
+
+	gx(function*() {
+
+		var item = yield Item.create({
+			collection_id: 1,
+			user_id: 1,
+			data: {
+				title: "Rung Ho!",
+				author: "Talbot Mundy",
+				isbn: "1557424047"
+			},
+		});
+
+		item.update({
+			data: {
+				title: "Rung Ho!",
+				author: "Talbot Mundy",
+				isbn: "55555"
+			}
+		});
+
+		// temporarily override the validator for isbn/number with a custom one
+		var isbn_field = item.collection.fields.filter(function(o) { return o.name === 'isbn'; }).pop();
+		isbn_field.control.validator = function(value,field,messages) {
+			messages.push("custom error message: "+value);
+			return 0;
+		};
+
+		var errors = item.validate();
+		isbn_field.control.validator = 'isNumeric'; // restore validator
+
+		test.deepEqual(errors, { isbn: 'Failed assertion: custom error message: 55555' });
+		test.done();
+	});
+};
+
 exports.build = function(test) {
 
 	gx(function*() {


### PR DESCRIPTION
In addition to executing canned validation from validators.js,
plugins can now provide their own validator hook

Note: I had issues running the project without updating gnode in package.json to "0.1.0"; let me know if that was done in error.