### PR TITLE
Ensure missing items don't cause service to fail

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -280,6 +280,8 @@ Item.load = function*(args) {
 	var data = yield models.items
 		.find({ where: criteria })
 		.complete(gx.resume);
+	
+	if (!data) return;
 
 	data.status = Status.name(data.status_id);
 

--- a/tests/item.js
+++ b/tests/item.js
@@ -261,6 +261,10 @@ exports.load = function(test) {
 		test.equal(item.data.author, "Talbot Mundy");
 		test.equal(item.data.isbn, "1557424047");
 		test.strictEqual(item.data.is_public_domain, true);
+
+		item2 = yield Item.load({ id: 0 });
+		test.equal(item2, undefined);
+
 		test.done();
 	})
 };


### PR DESCRIPTION
## Summary
If the item being fetched is missing, Sequelize returns undefined. An error occurs when data.status_id is referenced as data is undefined. This failure results in the application to error out and close. A better handling would be to treat the item as missing.

## How was this tested...

Add test in test/item.js
```
265     item2 = yield Item.load({ id: 0 });
266     test.equal(item2, undefined);
```

Run test...
```
rperlstein-mba:showcase rperlstein$ node node_modules/.bin/nodeunit tests/item.js

item.js

... // removed some logs

✔ build
inserted fixtures for table permissions
inserted fixtures for table statuses
inserted fixtures for table users
ERROR: TypeError: Cannot read property 'status_id' of null
    at Function.Item.load (/Users/rperlstein/code/shutterstock/showcase/lib/item.js:286:32)
```

Fix bug in lib/item.js
```
284   if (!data) return;
```

Run test...
```
rperlstein-mba:showcase rperlstein$ node node_modules/.bin/nodeunit tests/item.js

... // removed some logs

OK: 53 assertions (4037ms)
```

## Response from server
Headers
```
HTTP/1.1 404 Not Found
Server: nginx
Date: Mon, 06 May 2019 18:58:01 GMT
Content-Type: application/json; charset=utf-8
Transfer-Encoding: chunked
Connection: close
X-Powered-By: Express
ETag: "-423985999"
Content-Encoding: gzip
```
Body
```
{
  message: "couldn't find item",
  code: "no_item_found"
}
```